### PR TITLE
Fix Jdk11+ build errors during compilation and Java-doc generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <maven-versions-plugin.version>2.2</maven-versions-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.6</nexus-staging-maven-plugin.version>
         <commons-lang3.version>3.4</commons-lang3.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
         <junit-version>4.12</junit-version>
         <gson.version>2.5</gson.version>
     </properties>
@@ -250,6 +251,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
These changes address the following issues:

Fixes iyzico/iyzipay-java#96 : java.xml.bind module does no longer exist with Java 11

Fixes iyzico/iyzipay-java#97 : javadoc generation fails with JDK 11+