### PR TITLE
feature/DEV-8098 add new fields to checkout form initialize request

### DIFF
--- a/src/main/java/com/iyzipay/request/CreateCheckoutFormInitializeRequest.java
+++ b/src/main/java/com/iyzipay/request/CreateCheckoutFormInitializeRequest.java
@@ -167,6 +167,22 @@ public class CreateCheckoutFormInitializeRequest extends Request {
         this.debitCardAllowed = debitCardAllowed;
     }
 
+    public Boolean getSubscriptionPaymentEnabled() {
+        return subscriptionPaymentEnabled;
+    }
+
+    public void setSubscriptionPaymentEnabled(Boolean subscriptionPaymentEnabled) {
+        this.subscriptionPaymentEnabled = subscriptionPaymentEnabled;
+    }
+
+    public Boolean getPayWithIyzico() {
+        return payWithIyzico;
+    }
+
+    public void setPayWithIyzico(Boolean payWithIyzico) {
+        this.payWithIyzico = payWithIyzico;
+    }
+
     @Override
     public String toString() {
         return new ToStringRequestBuilder(this)

--- a/src/main/java/com/iyzipay/request/CreateCheckoutFormInitializeRequest.java
+++ b/src/main/java/com/iyzipay/request/CreateCheckoutFormInitializeRequest.java
@@ -28,6 +28,8 @@ public class CreateCheckoutFormInitializeRequest extends Request {
     private List<Integer> enabledInstallments;
     private Boolean paymentWithNewCardEnabled;
     private Boolean debitCardAllowed;
+    private Boolean subscriptionPaymentEnabled;
+    private Boolean payWithIyzico;
 
     public BigDecimal getPrice() {
         return price;
@@ -186,6 +188,8 @@ public class CreateCheckoutFormInitializeRequest extends Request {
                 .append("enabledInstallments", enabledInstallments)
                 .append("paymentWithNewCardEnabled", paymentWithNewCardEnabled)
                 .append("debitCardAllowed", debitCardAllowed)
+                .append("subscriptionPaymentEnabled", subscriptionPaymentEnabled)
+                .append("payWithIyzico", payWithIyzico)
                 .toString();
     }
 }


### PR DESCRIPTION
In order to initialize checkout form as "pay with iyzico form", we need a boolean flag during sending initialize request. I've added this. I also have added the missing "subscriptionPaymentEnabled" field to the request too.